### PR TITLE
Enable user registration on backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,12 @@ To run the backend code with a config file from AWS param store prefix the path 
 
 #### Creating users
 
-Once the backend is running, use the **apiKey** you set in the config file to create test users. The examples below use
-the default example port and API key.
+Once the backend is running you can create test users. The examples below use the default example port and API key.
 
 ```shell
 # create a test user named george
-curl -X POST -H "Todo-Api-Key: test" http://localhost:8080/api/users -d '{"name":"george", "password":"password"}'
-# fetch all users
+curl -X POST http://localhost:8080/api/users -d '{"name":"george", "password":"password"}'
+# fetch all users (requires the server API key)
 curl -H "Todo-Api-Key: test" http://localhost:8080/api/users
 # login with the newly created user named george and save the cookie in a file name httpcookie
 curl -X POST -d '{"name":"george","password":"password"}' http://localhost:8080/api/user/login -c httpcookie
@@ -97,9 +96,13 @@ curl -X POST -d '{"name":"george","password":"password"}' http://localhost:8080/
 curl -b httpcookie http://localhost:8080/api/user/key
 # read the user info
 curl -b httpcookie http://localhost:8080/api/user
+# user the user API key to read the user info
+curl -H "Authorization: Bearer <apikey>" http://localhost:8080/api/user
 # logout and delete the cookie
 curl -X DELETE -b httpcookie http://localhost:8080/api/user/logout && rm httpcookie
 ```
+
+
 
 #### Tests
 To run backend tests run one of the following commands:

--- a/backend/http/server.go
+++ b/backend/http/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cmokbel1/todo-app/backend/todo"
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/httprate"
 )
 
 type Server struct {
@@ -36,7 +37,11 @@ type Server struct {
 
 func NewServer() *Server {
 	s := &Server{
-		server:           &http.Server{},
+		server: &http.Server{
+			ReadTimeout:  time.Second * 6,
+			WriteTimeout: time.Second * 6,
+			IdleTimeout:  time.Second * 6,
+		},
 		Logger:           todo.NewLogger(),
 		LoggerMiddleware: middleware.Logger,
 	}
@@ -54,6 +59,8 @@ func (s *Server) Listen() (err error) {
 
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
+	// hard coded rate limit of 60 requests/minute/IP
+	r.Use(httprate.LimitByIP(60, time.Minute))
 	r.Use(s.LoggerMiddleware)
 	r.Use(s.cors)
 	r.Use(s.sessionMiddleware)

--- a/backend/http/user.go
+++ b/backend/http/user.go
@@ -16,7 +16,7 @@ func (s *Server) registerUserRoutes(r chi.Router) {
 	r.With(s.requireAuth).Delete("/user/logout", s.handleLogout)
 
 	r.With(s.requireAPIKey).Get("/users", s.handleUsersIndex)
-	r.With(s.requireAPIKey).Post("/users", s.handleUserCreate)
+	r.With(s.requireNoAuth).Post("/users", s.handleUserCreate)
 	r.Route("/users/{id}", func(r chi.Router) {
 		r.Use(s.requireIntParam("id"))
 		r.With(s.requireAPIKey).Delete("/", s.handleUserDelete)
@@ -119,6 +119,7 @@ func (s *Server) handleUserCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.Logger.Infof("created default list for user %q (list id = %d)", user.Name, list.ID)
+	user.Password = ""
 	s.json(w, r, http.StatusCreated, user)
 }
 

--- a/backend/http/user.go
+++ b/backend/http/user.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/cmokbel1/todo-app/backend/todo"
 	"github.com/go-chi/chi"
+	"github.com/go-chi/httprate"
 )
 
 func (s *Server) registerUserRoutes(r chi.Router) {
@@ -16,7 +18,8 @@ func (s *Server) registerUserRoutes(r chi.Router) {
 	r.With(s.requireAuth).Delete("/user/logout", s.handleLogout)
 
 	r.With(s.requireAPIKey).Get("/users", s.handleUsersIndex)
-	r.With(s.requireNoAuth).Post("/users", s.handleUserCreate)
+	// Limit calls to user create to 5 per minute across the entire instance
+	r.With(httprate.LimitAll(5, time.Minute), s.requireNoAuth).Post("/users", s.handleUserCreate)
 	r.Route("/users/{id}", func(r chi.Router) {
 		r.Use(s.requireIntParam("id"))
 		r.With(s.requireAPIKey).Delete("/", s.handleUserDelete)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/alexedwards/scs/v2 v2.5.0
 	github.com/aws/aws-sdk-go v1.44.24
 	github.com/go-chi/chi v1.5.4
+	github.com/go-chi/httprate v0.5.3
+	github.com/jackc/pgconn v1.12.0
 	github.com/jackc/pgx/v4 v4.16.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/pressly/goose/v3 v3.5.3
@@ -16,9 +18,9 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/golang/protobuf v1.5.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
-	github.com/jackc/pgconn v1.12.0 // indirect
 	github.com/jackc/pgio v1.0.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgproto3/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edY
 github.com/bkaradzic/go-lz4 v1.0.0/go.mod h1:0YdlkowM3VswSROI7qDxhRvJ3sLhlFrRRwjwegp5jy4=
 github.com/cenkalti/backoff/v4 v4.1.2/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
+github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/checkpoint-restore/go-criu/v5 v5.0.0/go.mod h1:cfwC0EG7HMUenopBsUf9d89JlCLQIfgVcNsNN0t6T2M=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
@@ -68,6 +70,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-chi/chi v1.5.4 h1:QHdzF2szwjqVV4wmByUnTcsbIg7UGaQ0tPF2t5GcAIs=
 github.com/go-chi/chi v1.5.4/go.mod h1:uaf8YgoFazUOkPBG7fxPftUylNumIev9awIWOENIuEg=
+github.com/go-chi/httprate v0.5.3 h1:5HPWb0N6ymIiuotMtCfOGpQKiKeqXVzMexHh1W1yXPc=
+github.com/go-chi/httprate v0.5.3/go.mod h1:kYR4lorHX3It9tTh4eTdHhcF2bzrYnCrRNlv5+IBm2M=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=


### PR DESCRIPTION
Opened up the user registration on the backend by removing the need for the server API key.

* Removed server API key requirement for POST /api/users
* Added global rate limit of 5 to POST /api/users
* Added per IP rate limit of 60 requests/minute to all HTTP routes
* Set some sane defaults for HTTP server READ/WRITE/IDLE timeouts
* Updated README